### PR TITLE
Refactor note types

### DIFF
--- a/packages/note/index.ts
+++ b/packages/note/index.ts
@@ -1,34 +1,34 @@
-type NoteLetter = "A" | "B" | "C" | "D" | "E" | "F" | "G";
-type NoteAccidental = string; // " " | "#" | "b" | " #" | " b"  | "b " | "b#" | "#b" ;
-type Note = string;
-type Midi = number;
-type Octave = number;
-type OrNull<T> = T | null;
-type NoteName = string;
+export type OrNull<T> = T | null;
+// A PC is a pitch class (letter, accidentals)
+// Examples: "C", "Db", "F#"
+export type PC = string; // Note letter + accidentals
+// A Note is a pitch class with octave (letter, accidentals, octave)
+// Examples: C2, Db5, F#4
+export type Note = string; // NoteLetter + NoteAccidental + Octave
 
-type NoteProps = {
-  name: NoteName;
-  letter: NoteLetter;
-  acc: NoteAccidental; // {String}: the note accidentals
-  oct: OrNull<Octave>; // {Number}: the octave or null if not present
-  step: number; // {Number}: number equivalent of the note letter. 0 means C ... 6 means B.
-  pc: NoteName; //{String}: the pitch class (letter + accidentals)
-  alt: number; // {Number}: number equivalent of accidentals (negative are flats, positive sharps)
-  chroma: number; // {Number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
-  midi: OrNull<Midi>; // {Number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
-  freq: OrNull<number>; // {Number}: the frequency using an equal temperament at 440Hz
+export type NoteProps = {
+  name: Note;
+  letter: string; // {string} note letter: "A" | "B" | "C" | "D" | "E" | "F" | "G";
+  acc: string; // {string} the note accidentals ("", "#", "bb", ...)
+  oct: number | null; // {number} the octave or null if not present
+  step: number; // {number} number equivalent of the note letter. 0 means C ... 6 means B.
+  pc: PC; // {string}: the pitch class (letter + accidentals)
+  alt: number; // {number}: number equivalent of accidentals (zero no accidentals, negative are flats, positive sharps)
+  chroma: number; // {number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
+  midi: number | null; // {number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
+  freq: OrNull<number>; // {number}: the frequency using an equal temperament at 440Hz
 };
 
-type NoNoteProps = {
+export type NoNoteProps = {
   name: null;
   // letter: null;
-  // acc: null; // {String}: the note accidentals
-  oct: null; // {Number}: the octave or null if not present
-  step: null; // {Number}: number equivalent of the note letter. 0 means C ... 6 means B.
-  pc: null; //{String}: the pitch class (letter + accidentals)
-  alt: null; // {Number}: number equivalent of accidentals (negative are flats, positive sharps)
-  chroma: null; // {Number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
-  midi: null; // {Number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
+  // acc: null; // {string}: the note accidentals
+  oct: null; // {number}: the octave or null if not present
+  step: null; // {number}: number equivalent of the note letter. 0 means C ... 6 means B.
+  pc: null; //{string}: the pitch class (letter + accidentals)
+  alt: null; // {number}: number equivalent of accidentals (negative are flats, positive sharps)
+  chroma: null; // {number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
+  midi: null; // {number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
   freq: null;
 };
 
@@ -68,11 +68,12 @@ type NoNoteProps = {
 
 const NAMES = "C C# Db D D# Eb E F F# Gb G G# Ab A A# Bb B".split(
   " "
-) as NoteName[];
+) as Note[];
 
 /**
  * Get a list of note names (pitch classes) within a octave
  *
+ * FIXME: 2.0 change signature to names({ plain: true, flats: true, sharps: false })
  * @param {string} accTypes - (Optional, by default " b#"). A string with the
  * accidentals types: " " means no accidental, "#" means sharps, "b" mean flats,
  * can be combined (see examples)
@@ -81,26 +82,28 @@ const NAMES = "C C# Db D D# Eb E F F# Gb G G# Ab A A# Bb B".split(
  * Note.names(" b") // => [ "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B" ]
  * Note.names(" #") // => [ "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B" ]
  */
-export const names = (accTypes?: NoteAccidental) =>
-  typeof accTypes !== "string"
+export function names(accTypes: string | undefined = undefined): Note[] {
+  return typeof accTypes !== "string"
     ? NAMES.slice()
     : NAMES.filter(n => {
         const acc = n[1] || " ";
         return accTypes.indexOf(acc) !== -1;
       });
+}
 
-const SHARPS = names(" #");
-const FLATS = names(" b");
-const REGEX = /^([a-gA-G]?)(#{1,}|b{1,}|x{1,}|)(-?\d*)\s*(.*)$/;
+const SHARPS: Note[] = names(" #");
+const FLATS: Note[] = names(" b");
+
+const TOKENIZE = /^([a-gA-G]?)(#{1,}|b{1,}|x{1,}|)(-?\d*)\s*(.*)$/;
 
 /**
  * Split a string into tokens related to note parts.
- * It returns an array of strings `[letter, accidental, octave, modifier]`
  *
- * It always returns an array
+ * It always returns an array of strings: `[letter, accidental, octave, modifier]`
  *
- * @param {String} str
- * @return {Array} an array of note tokens
+ * @param {string} str
+ * @return {string[]} an array with 4 strings (letter, accidental, octave, modified)
+ *
  * @example
  * Note.tokenize("C#2") // => ["C", "#", "2", ""]
  * Note.tokenize("Db3 major") // => ["D", "b", "3", "major"]
@@ -108,17 +111,10 @@ const REGEX = /^([a-gA-G]?)(#{1,}|b{1,}|x{1,}|)(-?\d*)\s*(.*)$/;
  * Note.tokenize("##") // => ["", "##", "", ""]
  * Note.tokenize() // => ["", "", "", ""]
  */
-export function tokenize(str?: Note | Midi) {
+export function tokenize(str: any): [string, string, string, string] {
   if (typeof str !== "string") str = "";
-  const m = REGEX.exec(str) as string[];
-  // Will never execute
-  // if (!m) return null;
-  return [m[1].toUpperCase(), m[2].replace(/x/g, "##"), m[3], m[4]] as [
-    NoteLetter | "",
-    string,
-    string,
-    string
-  ];
+  const m = TOKENIZE.exec(str) as string[];
+  return [m[1].toUpperCase(), m[2].replace(/x/g, "##"), m[3], m[4]];
 }
 
 const NO_NOTE = Object.freeze({
@@ -131,10 +127,15 @@ const NO_NOTE = Object.freeze({
   chroma: null,
   midi: null,
   freq: null
-} as NoNoteProps);
+}) as NoNoteProps;
 
 const SEMI = [0, 2, 4, 5, 7, 9, 11];
-const properties = (str: Note | Midi) => {
+
+/**
+ * @private
+ * Parse a note to obtain it's properties (public version is cached and it's called `Note.props`)
+ */
+function parse(str: string): NoteProps | NoNoteProps {
   const tokens = tokenize(str);
   // Will never execute
   // if (tokens === null) return NO_NOTE;
@@ -155,36 +156,32 @@ const properties = (str: Note | Midi) => {
   } as NoteProps;
   p.chroma = (SEMI[p.step] + p.alt + 120) % 12;
   p.midi = p.oct !== null ? SEMI[p.step] + p.alt + 12 * (p.oct + 1) : null;
-  p.freq = midiToFreq(p.midi);
+  p.freq = midiToFreq(p.midi as number);
   return Object.freeze(p);
-};
+}
 
-// function memo
-const memo = <T extends string | number, V>(
-  fn: (s: T) => V,
-  cache = {} as { [key in T]: V }
-) => (str: T) => cache[str] || (cache[str] = fn(str));
-
+const cached = {} as { [key in Note]: NoteProps | NoNoteProps };
 /**
  * Get note properties. It returns an object with the following information:
  *
- * - name {String}: the note name. The letter is always in uppercase
- * - letter {String}: the note letter, always in uppercase
- * - acc {String}: the note accidentals
- * - octave {Number}: the octave or null if not present
- * - pc {String}: the pitch class (letter + accidentals)
- * - step {Number}: number equivalent of the note letter. 0 means C ... 6 means B.
- * - alt {Number}: number equivalent of accidentals (negative are flats, positive sharps)
- * - chroma {Number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
- * - midi {Number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
- * - freq {Number}: the frequency using an equal temperament at 440Hz
+ * - name {string}: the note name. The letter is always in uppercase
+ * - letter {string}: the note letter, always in uppercase
+ * - acc {string}: the note accidentals
+ * - octave {number}: the octave or null if not present
+ * - pc {string}: the pitch class (letter + accidentals)
+ * - step {number}: number equivalent of the note letter. 0 means C ... 6 means B.
+ * - alt {number}: number equivalent of accidentals (negative are flats, positive sharps)
+ * - chroma {number}: number equivalent of the pitch class, where 0 is C, 1 is C# or Db, 2 is D...
+ * - midi {number}: the note midi number (IMPORTANT! it can be outside 0 to 127 range)
+ * - freq {number}: the frequency using an equal temperament at 440Hz
  *
  * This function *always* returns an object with all this properties, but if it"s
  * not a valid note all properties will be null.
  *
  * The returned object can"t be mutated.
  *
- * @param {String} note - the note name in scientific notation
+ * @function
+ * @param {string} note - the note name in scientific notation
  * @return {Object} an object with the properties (or an object will all properties
  * set to null if not valid note)
  * @example
@@ -193,7 +190,9 @@ const memo = <T extends string | number, V>(
  * Note.props("C#3").oct // => 3
  * Note.props().oct // => null
  */
-export const props = memo(properties);
+export function props(note: Note): NoteProps | NoNoteProps {
+  return cached[note] || (cached[note] = parse(note));
+}
 
 /**
  * Given a note name, return the note name or null if not valid note.
@@ -210,7 +209,9 @@ export const props = memo(properties);
  * Note.name("cb2") // => "Cb2"
  * ["c", "db3", "2", "g+", "gx4"].map(Note.name) // => ["C", "Db3", null, null, "G##4"]
  */
-export const name = (str: Note) => props(str).name as NoteName;
+export function name(str: Note | any): Note | null {
+  return props(str).name;
+}
 
 /**
  * Get pitch class of a note. The note can be a string or a pitch array.
@@ -222,50 +223,57 @@ export const name = (str: Note) => props(str).name as NoteName;
  * Note.pc("Db3") // => "Db"
  * ["db3", "bb6", "fx2"].map(Note.pc) // => [ "Db", "Bb", "F##"]
  */
-export const pc = (str: Note) => props(str).pc;
+export function pc(str: Note): PC | null {
+  return props(str).pc;
+}
 
-const isMidiRange = (m: Midi | number): m is Midi => m >= 0 && m <= 127;
+const isMidiRange = (m: number | number): m is number => m >= 0 && m <= 127;
 /**
- * Get the note midi number. It always return a number between 0 and 127
+ * Get the note midi number. **It always return a number between 0 and 127**
  *
  * @function
- * @param {string|Number} note - the note to get the midi number from
- * @return {Integer} the midi number or null if not valid pitch
+ * @param {string | number} note - the note to get the midi number from
+ * @return {number | null} the midi number or null if not valid pitch
  * @example
  * Note.midi("C4") // => 60
  * Note.midi(60) // => 60
  * @see midi.toMidi
  */
-export const midi = (note: Note | Midi) => {
+export function midi(note: Note | number): number | null {
   if (typeof note !== "number" && typeof note !== "string") {
     return null;
   }
-  const midi = props(note).midi;
+  const midi = props(note as Note).midi;
   const value = midi || midi === 0 ? midi : +note;
   return isMidiRange(value) ? value : null;
-};
+}
 
 /**
  * Get the frequency from midi number
  *
- * @param {Number} midi - the note midi number
- * @param {Number} tuning - (Optional) 440 by default
- * @return {Number} the frequency or null if not valid note midi
+ * @param {number} midi - the note midi number
+ * @param {number} tuning - (Optional) 440 by default
+ * @return {number} the frequency or null if not valid note midi
  */
-export const midiToFreq = (midi: Midi | Note | null, tuning = 440) =>
-  typeof midi === "number" ? Math.pow(2, (midi - 69) / 12) * tuning : null;
+export function midiToFreq(midi: number, tuning = 440): number | null {
+  return typeof midi === "number"
+    ? Math.pow(2, (midi - 69) / 12) * tuning
+    : null;
+}
 
 /**
  * Get the frequency of a note
  *
  * @function
- * @param {string|Number} note - the note name or midi note number
- * @return {Number} the frequency
+ * @param {string|number} note - the note name or midi note number
+ * @return {number} the frequency
  * @example
  * Note.freq("A4") // => 440
  * Note.freq(69) // => 440
  */
-export const freq = (note: Note | Midi) => props(note).freq || midiToFreq(note);
+export function freq(note: Note | number): number | null {
+  return props(note as Note).freq || midiToFreq(note as number);
+}
 
 const L2 = Math.log(2);
 const L440 = Math.log(440);
@@ -273,66 +281,80 @@ const L440 = Math.log(440);
  * Get the midi number from a frequency in hertz. The midi number can
  * contain decimals (with two digits precission)
  *
- * @param {Number} frequency
- * @return {Number}
+ * @param {number} frequency
+ * @return {number}
  * @example
  * Note.freqToMidi(220)); //=> 57;
  * Note.freqToMidi(261.62)); //=> 60;
  * Note.freqToMidi(261)); //=> 59.96;
  */
-export const freqToMidi = (freq: number) => {
+export function freqToMidi(freq: number): number {
   const v = (12 * (Math.log(freq) - L440)) / L2 + 69;
   return Math.round(v * 100) / 100;
-};
+}
 
 /**
  * Return the chroma of a note. The chroma is the numeric equivalent to the
  * pitch class, where 0 is C, 1 is C# or Db, 2 is D... 11 is B
  *
- * @param {string} note - the note name
- * @return {Integer} the chroma number
+ * @param {string} note - the note or pitch class name
+ * @return {number | null} the chroma (0...11) or null if not valid note or pitch class
+ *
  * @example
  * Note.chroma("Cb") // => 11
  * ["C", "D", "E", "F"].map(Note.chroma) // => [0, 2, 4, 5]
  */
-export const chroma = (str: Note) => props(str).chroma;
+export function chroma(str: Note | PC): number | null {
+  return props(str).chroma;
+}
 
 /**
  * Get the octave of the given pitch
  *
- * @function
- * @param {string} note - the note
- * @return {Integer} the octave or null if doesn"t have an octave or not a valid note
+ * @param {string} note - the note name
+ * @return {number | null} the octave number or null if it's a pitch class or a not valid note
+ *
  * @example
  * Note.oct("C#4") // => 4
  * Note.oct("C") // => null
  * Note.oct("blah") // => undefined
  */
-export const oct = (str: Note) => props(str).oct;
+export function oct(str: Note): number | null {
+  return props(str).oct;
+}
 
 const LETTERS = "CDEFGAB";
 /**
  * Given a step number return it's letter (0 = C, 1 = D, 2 = E)
- * @param {number} step
- * @return {string} the letter
+ *
+ * @param {number} step - a number between 0 and 6
+ * @return {string | undefined} the letter or undefined if not a valid step number
+ *
  * @example
  * Note.stepToLetter(3) // => "F"
  */
-export const stepToLetter = (step: number) => LETTERS[step];
+export function stepToLetter(step: number): string | undefined {
+  // FIXME: for consistency, it should return null
+  return LETTERS[step];
+}
 
+// create a string with n strings
 const fillStr = (s: string, n: number) => Array(n + 1).join(s);
-const numToStr = (num: number | any, op: (a: number) => string) =>
-  typeof num !== "number" ? "" : op(num);
+// create a string with accidentals (depending on number's sign)
+const fillAcc = (n: number) => (n < 0 ? fillStr("b", -n) : fillStr("#", n));
 
 /**
  * Given an alteration number, return the accidentals
- * @param {Number} alt
- * @return {String}
+ *
+ * @param {number} alt - the alteration number (negative mean flats)
+ * @return {string} the string with the accidentals
+ *
  * @example
  * Note.altToAcc(-3) // => "bbb"
  */
-export const altToAcc = (alt?: number) =>
-  numToStr(alt, alt => (alt < 0 ? fillStr("b", -alt) : fillStr("#", alt)));
+export function altToAcc(alt: number): string {
+  return typeof alt === "number" ? fillAcc(alt) : "";
+}
 
 /**
  * Creates a note name in scientific notation from note properties,
@@ -346,22 +368,22 @@ export const altToAcc = (alt?: number) =>
  * received on the first parameter will be taken from that base note. That way it can be used
  * as an immutable "set" operator for a that base note
  *
- * @function
- * @param {Object} props - the note properties
- * @param {String} [baseNote] - note to build the result from. If given, it returns
+ * @param {object} props - the note properties ({ step, alt, oct })
+ * @param {string} [baseNote] - note to build the result from. If given, it returns
  * the result of applying the given props to this note.
- * @return {String} the note name in scientific notation or null if not valid properties
+ * @return {string | null} the note name in scientific notation or null if not valid properties
+ *
  * @example
  * Note.from({ step: 5 }) // => "A"
- * Note.from({ step: 1, acc: -1 }) // => "Db"
- * Note.from({ step: 2, acc: 2, oct: 2 }) // => "E##2"
+ * Note.from({ step: 1, alt: -1 }) // => "Db"
+ * Note.from({ step: 2, alt: 2, oct: 2 }) // => "E##2"
  * Note.from({ step: 7 }) // => null
  * Note.from({alt: 1, oct: 3}, "C4") // => "C#3"
  */
-export const from = (
+export function from(
   fromProps = {} as Partial<NoteProps>,
   baseNote: OrNull<Note> = null
-) => {
+): Note | null {
   const { step, alt, oct } = baseNote
     ? Object.assign({}, props(baseNote), fromProps)
     : fromProps;
@@ -369,11 +391,12 @@ export const from = (
   // if (typeof alt !== "number") return null
   const letter = stepToLetter(step);
   if (!letter) return null;
-  const pc = letter + altToAcc(alt);
+  const pc = letter + altToAcc(alt as number);
   return oct || oct === 0 ? pc + oct : pc;
-};
+}
 
 /**
+ * FIXME: remove in 3.0
  * Deprecated. This is kept for backwards compatibility only.
  * Use Note.from instead
  */
@@ -383,7 +406,6 @@ export const build = from;
  * Given a midi number, returns a note name. The altered notes will have
  * flats unless explicitly set with the optional `useSharps` parameter.
  *
- * @function
  * @param {number} midi - the midi note number
  * @param {boolean} useSharps - (Optional) set to true to use sharps instead of flats
  * @return {string} the note name
@@ -393,28 +415,28 @@ export const build = from;
  * // it rounds to nearest note
  * Note.fromMidi(61.7) // => "D4"
  */
-export function fromMidi(num: Midi, sharps: boolean | number = false) {
-  num = Math.round(num);
-  const pcs = sharps === true ? SHARPS : FLATS;
-  const pc = pcs[num % 12];
-  const o = Math.floor(num / 12) - 1;
+export function fromMidi(m: number, useSharps: boolean = false): Note {
+  const midi = Math.round(m);
+  const pcs = useSharps === true ? SHARPS : FLATS;
+  const pc = pcs[midi % 12];
+  const o = Math.floor(midi / 12) - 1;
   return pc + o;
 }
 
 /**
  * Simplify the note: find an enhramonic note with less accidentals.
  *
- * @param {String} note - the note to be simplified
+ * @param {string} note - the note to be simplified
  * @param {boolean} useSameAccType - (optional, true by default) set to true
  * to ensure the returned note has the same accidental types that the given note
- * @return {String} the simplfiied note or null if not valid note
+ * @return {string | null} the simplfiied note or null if not valid note
  * @example
  * Note.simplify("C##") // => "D"
  * Note.simplify("C###") // => "D#"
  * Note.simplify("C###", false) // => "Eb"
  * Note.simplify("B#4") // => "C5"
  */
-export const simplify = (note: Note, sameAcc: number | boolean = true) => {
+export function simplify(note: Note, sameAcc: boolean = true): Note | null {
   const { alt, chroma, midi } = props(note);
   if (chroma === null) return null;
   const alteration = alt as number;
@@ -422,15 +444,16 @@ export const simplify = (note: Note, sameAcc: number | boolean = true) => {
   return midi === null
     ? pc(fromMidi(chroma, useSharps))
     : fromMidi(midi, useSharps);
-};
+}
 
 /**
  * Get the simplified and enhramonic note of the given one.
  *
- * @param {String} note
- * @return {String} the enhramonic note
+ * @function
+ * @param {string} note
+ * @return {string} the enhramonic note
  * @example
  * Note.enharmonic("Db") // => "C#"
  * Note.enhramonic("C") // => "C"
  */
-export const enharmonic = (note: Note) => simplify(note, false);
+export const enharmonic = (note: Note): Note | null => simplify(note, false);


### PR DESCRIPTION
## What this PR do?

Refactor the types (and some code) of `tonal-note` and `tonal-intervals`

## Types of changes

- [x] Refactor

### Why are we doing this? Any context or related work?

To enforce the same TypeScript style across all modules and remove some noise from types that are not required to understand the code:

- Export types
- Note and NoteName are the same concepts. Remove NoteName
- Return values of public functions are always explicitly typed
- Remove some types that creates more noise than value: Octave, Midi, NoteLetter, NoteAccidentals
- All exported functions are declared with `function` instead of `=>`

### Where should a reviewer start?


## How has this been tested? How can we test it?


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
