### PR TITLE
Corrected doc entry for the `modeNames()` function

### DIFF
--- a/extensions/key/index.js
+++ b/extensions/key/index.js
@@ -43,9 +43,9 @@ const modenum = mode => NUMS[MODES.indexOf(mode)];
  * @param {Boolean} alias - true to get aliases names
  * @return {Array} an array of strings
  * @example
- * Key.modes() // => [ "ionian", "dorian", "phrygian", "lydian",
+ * Key.modeNames() // => [ "ionian", "dorian", "phrygian", "lydian",
  * // "mixolydian", "aeolian", "locrian" ]
- * Key.modes(true) // => [ "ionian", "dorian", "phrygian", "lydian",
+ * Key.modeNames(true) // => [ "ionian", "dorian", "phrygian", "lydian",
  * // "mixolydian", "aeolian", "locrian", "major", "minor" ]
  */
 export const modeNames = aliases =>


### PR DESCRIPTION
The examples in the doc entry for the `modeNames()` function referred to a non-existing `modes()` method.

I've skipped most of the details required in the PR since it's a simple documentation change.
