### PR TITLE
fix diatonic chord names of harmonic/melodic minor keys

### DIFF
--- a/packages/key/index.ts
+++ b/packages/key/index.ts
@@ -85,13 +85,13 @@ const NaturalScale = keyScale(
 );
 const HarmonicScale = keyScale(
   "I II bIII IV V bVI VII",
-  "mmaj7 m7b5 +maj7 m7 7 maj7 mo7",
+  "mM7 m7b5 +7 m7 7 maj7 o7",
   "T SD T SD D SD D",
   "harmonic minor,locrian 6,major augmented,lydian diminished,phrygian dominant,lydian #9,ultralocrian"
 );
 const MelodicScale = keyScale(
   "I II bIII IV V VI VII",
-  "m6 m7 +maj7 7 7 m7b5 m7b5",
+  "m6 m7 +7 7 7 m7b5 m7b5",
   "T SD T SD D - -",
   "melodic minor,dorian b2,lydian augmented,lydian dominant,mixolydian b6,locrian #2,altered"
 );


### PR DESCRIPTION
# PR Purpose
Hi. Thanks for creating Tonal libraries. 
I'm making this PR to fix diatonic chord names of harmonic and minor keys.
Now, Harmonic minor's diatonic chords are expressed as below:

```
"mmaj7 m7b5 +maj7 m7 7 maj7 mo7"
```

but for example, "mmaj7", "+maj", and "mo7" aren't able to recognized by chord module.

```
const Chord = require('@tonaljs/chord');
console.log(Chord.chord("Cmmaj7")); 
// {
//  empty: true,
//  name: '',
//  type: '',
//  tonic: null,
//  setNum: NaN,
//  quality: 'Unknown',
//  chroma: '',
//  normalized: '',
//  aliases: [],
//  notes: [],
//  intervals: []
// } 
```

I'd like to use minor diatonic chord names for chord module.  Please check my commit. 
Thanks.