### PR TITLE
Fix typo in package.json types: "index.dt.ts" -> "index.d.ts"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "main": "packages/tonal/dist/index.js",
   "module": "packages/tonal/dist/index.es.js",
-  "types": "packages/tonal/dist/index.dt.ts",
+  "types": "packages/tonal/dist/index.d.ts",
   "scripts": {
     "lerna": "lerna bootstrap",
     "lerna:publish": "yarn test:ci && lerna publish",

--- a/packages/array/package.json
+++ b/packages/array/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2"
   },

--- a/packages/chord-detect/package.json
+++ b/packages/chord-detect/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/chord-type": "^3.5.3",
     "@tonaljs/core": "^3.5.2",

--- a/packages/chord-dictionary/package.json
+++ b/packages/chord-dictionary/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/chord-type": "^3.5.3"
   },

--- a/packages/chord-type/package.json
+++ b/packages/chord-type/package.json
@@ -15,7 +15,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2",
     "@tonaljs/pcset": "^3.5.2"

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/chord-detect": "^3.5.3",
     "@tonaljs/chord-type": "^3.5.3",

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -12,7 +12,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "author": "danigb@gmail.com",
   "license": "MIT",
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "author": "danigb@gmail.com",
   "license": "MIT",
   "publishConfig": {

--- a/packages/duration-value/package.json
+++ b/packages/duration-value/package.json
@@ -12,7 +12,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "author": "danigb@gmail.com",
   "license": "MIT",
   "publishConfig": {

--- a/packages/interval/package.json
+++ b/packages/interval/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2"
   },

--- a/packages/key/package.json
+++ b/packages/key/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2",
     "@tonaljs/note": "^3.5.2",

--- a/packages/midi/package.json
+++ b/packages/midi/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2"
   },

--- a/packages/mode/package.json
+++ b/packages/mode/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2",
     "@tonaljs/pcset": "^3.5.2"

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/tonal": "^3.7.2"
   },

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2",
     "@tonaljs/midi": "^3.5.2"

--- a/packages/pcset/package.json
+++ b/packages/pcset/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/collection": "^3.5.2",
     "@tonaljs/core": "^3.5.2"

--- a/packages/pitch-notation-abc/package.json
+++ b/packages/pitch-notation-abc/package.json
@@ -20,7 +20,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/pitch-notation-interval/package.json
+++ b/packages/pitch-notation-interval/package.json
@@ -19,7 +19,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/pitch-notation-scientific/package.json
+++ b/packages/pitch-notation-scientific/package.json
@@ -18,7 +18,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/pitch-notation/package.json
+++ b/packages/pitch-notation/package.json
@@ -16,7 +16,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/pitch/package.json
+++ b/packages/pitch/package.json
@@ -13,7 +13,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/progression/package.json
+++ b/packages/progression/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/chord": "^3.6.2",
     "@tonaljs/core": "^3.5.2",

--- a/packages/range/package.json
+++ b/packages/range/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/collection": "^3.5.2",
     "@tonaljs/midi": "^3.5.2"

--- a/packages/roman-numeral/package.json
+++ b/packages/roman-numeral/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2"
   },

--- a/packages/scale-dictionary/package.json
+++ b/packages/scale-dictionary/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/scale-type": "^3.5.3"
   },

--- a/packages/scale-type/package.json
+++ b/packages/scale-type/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/core": "^3.5.2",
     "@tonaljs/pcset": "^3.5.2"

--- a/packages/scale/package.json
+++ b/packages/scale/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/chord-type": "^3.5.3",
     "@tonaljs/collection": "^3.5.2",

--- a/packages/time-signature/package.json
+++ b/packages/time-signature/package.json
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "author": "danigb@gmail.com",
   "license": "MIT",
   "publishConfig": {

--- a/packages/tonal/package.json
+++ b/packages/tonal/package.json
@@ -17,7 +17,7 @@
     "dist",
     "browser"
   ],
-  "types": "dist/index.dt.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@tonaljs/abc-notation": "^3.5.3",
     "@tonaljs/array": "^3.2.7",


### PR DESCRIPTION
Fixes #174
The typo was in 29 package.json files

![image](https://user-images.githubusercontent.com/2879020/80938897-05cba900-8d98-11ea-823c-2090252cdb79.png)
