### PR TITLE
Chord inversions

### DIFF
--- a/packages/chord/README.md
+++ b/packages/chord/README.md
@@ -43,9 +43,9 @@ Chord.getChord("maj7", "G4", "B4"); // =>
 //   type: "major seventh",
 //   aliases: ["maj7", "Δ", "ma7", "M7", "Maj7"],
 //   chroma: "100010010001",
-//   intervals: ["1P", "3M", "5P", "7M"],
+//   intervals: ["3M", "5P", "7M", "8P"],
 //   normalized: "100010010001",
-//   notes: ["G4", "B4", "D5", "F#5"],
+//   notes: ["B4", "D5", "F#5", "G5"],
 //   quality: "Major",
 // }
 ```

--- a/packages/chord/index.ts
+++ b/packages/chord/index.ts
@@ -134,15 +134,25 @@ export function getChord(
     return NoChord;
   }
 
+  const intervals = Array.from(type.intervals);
+
+  for (let i = 1; i < rootDegree; i++) {
+    const [num, quality] = intervals[0];
+    const newNum = parseInt(num, 10) + 7;
+    intervals.push(`${newNum}${quality}`);
+    intervals.shift();
+  }
+
   const notes = tonic.empty
     ? []
-    : type.intervals.map((i) => transposeNote(tonic, i));
+    : intervals.map((i) => transposeNote(tonic, i));
+
   typeName = type.aliases.indexOf(typeName) !== -1 ? typeName : type.aliases[0];
   const symbol = `${tonic.empty ? "" : tonic.pc}${typeName}${
-    root.empty ? "" : "/" + root.pc
+    root.empty || rootDegree <= 1 ? "" : "/" + root.pc
   }`;
   const name = `${optionalTonic ? tonic.pc + " " : ""}${type.name}${
-    optionalRoot ? " over " + root.pc : ""
+    rootDegree > 1 && optionalRoot ? " over " + root.pc : ""
   }`;
   return {
     ...type,
@@ -150,6 +160,7 @@ export function getChord(
     symbol,
     type: type.name,
     root: root.name,
+    intervals,
     rootDegree,
     tonic: tonic.name,
     notes,

--- a/packages/chord/test.ts
+++ b/packages/chord/test.ts
@@ -22,7 +22,25 @@ describe("tonal-chord", () => {
   });
 
   describe("getChord", () => {
-    test("Chord properties", () => {
+    test("Chord properites", () => {
+      expect(Chord.getChord("maj7", "G4", "G4")).toEqual({
+        empty: false,
+        name: "G major seventh",
+        symbol: "Gmaj7",
+        tonic: "G4",
+        root: "G4",
+        rootDegree: 1,
+        setNum: 2193,
+        type: "major seventh",
+        aliases: ["maj7", "Δ", "ma7", "M7", "Maj7", "^7"],
+        chroma: "100010010001",
+        intervals: ["1P", "3M", "5P", "7M"],
+        normalized: "100010010001",
+        notes: ["G4", "B4", "D5", "F#5"],
+        quality: "Major",
+      });
+    });
+    test("first inversion", () => {
       expect(Chord.getChord("maj7", "G4", "B4")).toEqual({
         empty: false,
         name: "G major seventh over B",
@@ -34,9 +52,45 @@ describe("tonal-chord", () => {
         type: "major seventh",
         aliases: ["maj7", "Δ", "ma7", "M7", "Maj7", "^7"],
         chroma: "100010010001",
-        intervals: ["1P", "3M", "5P", "7M"],
+        intervals: ["3M", "5P", "7M", "8P"],
         normalized: "100010010001",
-        notes: ["G4", "B4", "D5", "F#5"],
+        notes: ["B4", "D5", "F#5", "G5"],
+        quality: "Major",
+      });
+    });
+    test("first inversion without octave", () => {
+      expect(Chord.getChord("maj7", "G", "B")).toEqual({
+        empty: false,
+        name: "G major seventh over B",
+        symbol: "Gmaj7/B",
+        tonic: "G",
+        root: "B",
+        rootDegree: 2,
+        setNum: 2193,
+        type: "major seventh",
+        aliases: ["maj7", "Δ", "ma7", "M7", "Maj7", "^7"],
+        chroma: "100010010001",
+        intervals: ["3M", "5P", "7M", "8P"],
+        normalized: "100010010001",
+        notes: ["B", "D", "F#", "G"],
+        quality: "Major",
+      });
+    });
+    test("second inversion", () => {
+      expect(Chord.getChord("maj7", "G4", "D5")).toEqual({
+        empty: false,
+        name: "G major seventh over D",
+        symbol: "Gmaj7/D",
+        tonic: "G4",
+        root: "D5",
+        rootDegree: 3,
+        setNum: 2193,
+        type: "major seventh",
+        aliases: ["maj7", "Δ", "ma7", "M7", "Maj7", "^7"],
+        chroma: "100010010001",
+        intervals: ["5P", "7M", "8P", "10M"],
+        normalized: "100010010001",
+        notes: ["D5", "F#5", "G5", "B5"],
         quality: "Major",
       });
     });


### PR DESCRIPTION
I've updated the `getChord()` method to properly handle different roots:

Running this:
```typescript
Chord.getChord("maj7", "G4", "B4")
```

now returns 
```typescript
{ 
... 
intervals: ["3M", "5P", "7M", "8P"] // old value: ["1P", "3M", "5P", "7M"]
notes: ["B4", "D5", "F#5", "G5"] // old value: ["G4", "B4", "D5", "F#5"]
... 
}
``` 

I've written tests for first and second inversions, and updated the readme accordingly. Let me know if there's anything else I should do.