### PR TITLE
ABC notation documentation fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The API documentation lives inside README.md file of each module
 - [@tonaljs/note](/packages/note): Note operations (simplify, transposeBy )
 - [@tonaljs/midi](/packages/midi): Midi number conversions
 - [@tonaljs/interval](/packages/interval): Interval operations (add, simplify, invert)
-- [@tonaljs/abc-notation](/packages/abc-notation): Parse ABC notation notes
+- [@tonaljs/pitch-notation-abc](/packages/pitch-notation-abc): Parse ABC notation notes
 
 #### Scales and chords
 

--- a/packages/pitch-notation-abc/README.md
+++ b/packages/pitch-notation-abc/README.md
@@ -25,4 +25,6 @@ AbcNotation.scientificToAbcNotation("C#4"); // => "^C"
 ## References
 
 - [ABC Notation in Wikipedia](https://en.wikipedia.org/wiki/ABC_notation)
+- [ABC Notation learning materials](https://abcnotation.com/learn)
+- [ABC Notation standard documentation (old and new)](https://abcnotation.com/wiki/abc:standard)
 - [ABC in BCN format](https://web.archive.org/web/20080309023424/http://www.norbeck.nu/abc/abcbnf.htm)


### PR DESCRIPTION
- Pointed link to correct, non-deprecated package.
- Added additional reference links to package README.

A couple of small documentation tweaks to allow users and contributors to get into the `pitch-notation-abc` package faster.