### PR TITLE
assume perfect fifth

### DIFF
--- a/packages/chord-detect/index.ts
+++ b/packages/chord-detect/index.ts
@@ -1,4 +1,4 @@
-import { all } from "@tonaljs/chord-type";
+import { all, ChordType } from "@tonaljs/chord-type";
 import { note } from "@tonaljs/core";
 import { modes } from "@tonaljs/pcset";
 
@@ -19,13 +19,13 @@ const namedSet = (notes: string[]) => {
   return (chroma: number) => pcToName[chroma];
 };
 
-export function detect(source: string[]): string[] {
+export function detect(source: string[], assumePerfectFifth: boolean = false): string[] {
   const notes = source.map((n) => note(n).pc).filter((x) => x);
   if (note.length === 0) {
     return [];
   }
 
-  const found: FoundChord[] = findExactMatches(notes, 1);
+  const found: FoundChord[] = findExactMatches(notes, 1, assumePerfectFifth);
 
   return found
     .filter((chord) => chord.weight)
@@ -33,7 +33,34 @@ export function detect(source: string[]): string[] {
     .map((chord) => chord.name);
 }
 
-function findExactMatches(notes: string[], weight: number): FoundChord[] {
+// 3m 000100000000
+// 3M 000010000000
+// 5d 000000100000
+// 5P 000000010000
+// 5A 000000001000
+// 7m 000000000010
+// 7M 000000000001
+function has3x_5P_7x(chordType: ChordType) {
+  const cromaNum = parseInt(chordType.chroma, 2)
+  return ((cromaNum & 384) && (cromaNum & 16) && (cromaNum & 3))
+
+  /*return (chordType.intervals.some(interval => ['3M', '3m'].includes(interval))) &&
+  (chordType.intervals.some(interval => ['5P'].includes(interval))) &&
+  (chordType.intervals.some(interval => ['7M', '7m'].includes(interval)))*/
+}
+
+function maybeAddPerfectFifth(chroma: string): string {
+  const cromaNum = parseInt(chroma, 2)
+  return (cromaNum & 40)? chroma : (cromaNum | 16).toString(2)
+
+  /*if(str[6] === '1' || str[8] === '1')
+    return str
+  const ret = str.split('');
+  ret[7] = '1';
+  return ret.join('');*/
+}
+
+function findExactMatches(notes: string[], weight: number, assumePerfectFifth: boolean = false): FoundChord[] {
   const tonic = notes[0];
   const tonicChroma = note(tonic).chroma;
   const noteName = namedSet(notes);
@@ -42,8 +69,14 @@ function findExactMatches(notes: string[], weight: number): FoundChord[] {
 
   const found: FoundChord[] = [];
   allModes.forEach((mode, index) => {
+    const assumedMode = maybeAddPerfectFifth(mode)
     // some chords could have the same chroma but different interval spelling
-    const chordTypes = all().filter((chordType) => chordType.chroma === mode);
+    const chordTypes = all().filter((chordType) => {
+      if(assumePerfectFifth && has3x_5P_7x(chordType)) {
+        return chordType.chroma === assumedMode
+      }
+      return chordType.chroma === mode
+    });
 
     chordTypes.forEach((chordType) => {
       const chordName = chordType.aliases[0];

--- a/packages/chord-detect/test.ts
+++ b/packages/chord-detect/test.ts
@@ -8,6 +8,14 @@ describe("@tonal/chord-detect", () => {
     expect(detect(["E", "G#", "B", "C#"])).toEqual(["E6", "C#m7/E"]);
   });
 
+  test("assume perfect 5th", () => {
+    expect(detect(["D", "F", "C"], true)).toEqual(["Dm7"]);
+    expect(detect(["D", "F", "C"], false)).toEqual([]);
+    expect(detect(["D", "F", "A", "C"], true)).toEqual(["Dm7", "F6/D"]);
+    expect(detect(["D", "F", "A", "C"], false)).toEqual(["Dm7", "F6/D"]);
+    expect(detect(["D", "F", "Ab", "C"], true)).toEqual(["Dm7b5", "Fm6/D"]);
+  })
+
   test("(regression) detect aug", () => {
     expect(detect(["C", "E", "G#"])).toEqual(["Caug", "Eaug/C", "G#aug/C"]);
   });


### PR DESCRIPTION
following up on https://github.com/tonaljs/tonal/issues/234 I opened this PR to allow detecting chords even when the 5th is omitted (happening often when playing guitar)

this patch allows `Tonal.Chord.detect(["D", "F", "C"])` to return ["Dm7"]

this is just a stub with few proposal of how this could be achieved. I liked that chroma is basically a binary sequence so you can play with bitwise logic but that's personal taste, I don't mind if you feel like going for a more expressive code such as the one I left commented out. We could make it more expressive or better commented if we like it but I wanted some feedbacks first.

also as pointed out by KaipoJames in the aforementioned issue, we can use this logic to also identify 9th chords but I wanted to kick off the discussion first

as you can see I added a flag to enable the behaviour, but maybe we can achieve a solution which is always correct and we can remove it

if you have any test case you'd like to add feel free to mention it and I'll add it