### PR TITLE
Fix getChord failing to detect rootDegree for alternative interval names.

### DIFF
--- a/packages/chord/index.ts
+++ b/packages/chord/index.ts
@@ -15,7 +15,7 @@ import {
 } from "@tonaljs/core";
 
 import { isSubsetOf, isSupersetOf } from "@tonaljs/pcset";
-
+import { semitones, simplify } from "@tonaljs/interval";
 import { all as scaleTypes } from "@tonaljs/scale-type";
 export { detect } from "@tonaljs/chord-detect";
 
@@ -128,8 +128,8 @@ export function getChord(
     return NoChord;
   }
 
-  const rootInterval = distance(tonic.pc, root.pc);
-  const rootDegree = type.intervals.indexOf(rootInterval) + 1;
+  const rootInterval = semitones(distance(tonic.pc, root.pc));
+  const rootDegree = type.intervals.map(i => semitones(simplify(i))).indexOf(rootInterval) + 1;
   if (!root.empty && !rootDegree) {
     return NoChord;
   }

--- a/packages/chord/test.ts
+++ b/packages/chord/test.ts
@@ -103,7 +103,7 @@ describe("tonal-chord", () => {
     });
     test("rootDegrees", () => {
       expect(Chord.getChord("maj7", "C", "C").rootDegree).toBe(1);
-      expect(Chord.getChord("maj", "A", "E").rootDegree).toBe(3);
+      expect(Chord.getChord("maj", "A2", "Db2").rootDegree).toBe(2);
       expect(Chord.getChord("maj7", "C", "D").empty).toBe(true);
     });
     test("without tonic nor root", () => {

--- a/packages/chord/test.ts
+++ b/packages/chord/test.ts
@@ -103,6 +103,7 @@ describe("tonal-chord", () => {
     });
     test("rootDegrees", () => {
       expect(Chord.getChord("maj7", "C", "C").rootDegree).toBe(1);
+      expect(Chord.getChord("maj", "A", "E").rootDegree).toBe(3);
       expect(Chord.getChord("maj7", "C", "D").empty).toBe(true);
     });
     test("without tonic nor root", () => {


### PR DESCRIPTION
When attempting to parse 'A / Db' with getChord('maj', 'A', 'Db'), the rootDegree is not found, thus returning a root A chord object. This is because the distance calculated is expressed as '4d' rather than '3M'.

This PR simplifies both the distance calculation and interval array into semitones before checking for the rootDegree. Allowing alternate names for the same interval to be used when parsing inversions.