### PR TITLE
Fix Abc notation bug in the 0 octave.

### DIFF
--- a/packages/abc-notation/index.ts
+++ b/packages/abc-notation/index.ts
@@ -49,7 +49,7 @@ export function abcToScientificNotation(str: string): string {
  */
 export function scientificToAbcNotation(str: string): string {
   const n = note(str);
-  if (n.empty || !n.oct) {
+  if (n.empty || (!n.oct && n.oct !== 0)) {
     return "";
   }
   const { letter, acc, oct } = n;

--- a/packages/abc-notation/test.ts
+++ b/packages/abc-notation/test.ts
@@ -17,14 +17,44 @@ describe("@tonaljs/abc-notation", () => {
   });
 
   test("toNote", () => {
-    const ABC = ["__A,,", "_B,", "=C", "d", "^e'", "^^f''", "G,,''", "g,,,'''"];
-    const SCIENTIFIC = ["Abb2", "Bb3", "C4", "D5", "E#6", "F##7", "G4", "G5"];
+    const ABC = [
+      "__A,,",
+      "_B,",
+      "=C",
+      "d",
+      "^e'",
+      "^^f''",
+      "G,,''",
+      "g,,,'''",
+      "",
+    ];
+    const SCIENTIFIC = [
+      "Abb2",
+      "Bb3",
+      "C4",
+      "D5",
+      "E#6",
+      "F##7",
+      "G4",
+      "G5",
+      "",
+    ];
     expect(ABC.map(AbcNotation.abcToScientificNotation)).toEqual(SCIENTIFIC);
   });
 
   test("toAbc", () => {
-    const SCIENTIFIC = ["Abb2", "Bb3", "C4", "D5", "E#6", "F##7", "G#2", "Gb7"];
-    const ABC = ["__A,,", "_B,", "C", "d", "^e'", "^^f''", "^G,,", "_g''"];
+    const SCIENTIFIC = [
+      "Abb2",
+      "Bb3",
+      "C4",
+      "D5",
+      "E#6",
+      "F##7",
+      "G#2",
+      "Gb7",
+      "",
+    ];
+    const ABC = ["__A,,", "_B,", "C", "d", "^e'", "^^f''", "^G,,", "_g''", ""];
     expect(SCIENTIFIC.map(AbcNotation.scientificToAbcNotation)).toEqual(ABC);
   });
   test("toAbc Octave 0", () => {

--- a/packages/abc-notation/test.ts
+++ b/packages/abc-notation/test.ts
@@ -27,4 +27,17 @@ describe("@tonaljs/abc-notation", () => {
     const ABC = ["__A,,", "_B,", "C", "d", "^e'", "^^f''", "^G,,", "_g''"];
     expect(SCIENTIFIC.map(AbcNotation.scientificToAbcNotation)).toEqual(ABC);
   });
+  test("toAbc Octave 0", () => {
+    const SCIENTIFIC = ["A0", "Bb0", "C0", "D0", "E#0", "F##0", "G#0"];
+    const ABC = [
+      "A,,,,",
+      "_B,,,,",
+      "C,,,,",
+      "D,,,,",
+      "^E,,,,",
+      "^^F,,,,",
+      "^G,,,,",
+    ];
+    expect(SCIENTIFIC.map(AbcNotation.scientificToAbcNotation)).toEqual(ABC);
+  });
 });


### PR DESCRIPTION
A fix of the issue glend1 opened: a bug in octave 0 when using the scientificToAbcNotation function in abc-notation. The issue was that the function returned an empty string if the value was falsey, which includes zeros that should be there.

I wrote a test for the bug fix, and also tested that putting in an empty string returns an empty string, bringing test coverage of abc-notation up to 100%. Thanks! I love tonal, this is my first time contributing.