### PR TITLE
Fix octave overflow in Scale.rangeOf

### DIFF
--- a/packages/scale/index.ts
+++ b/packages/scale/index.ts
@@ -6,7 +6,7 @@
 import { all as chordTypes } from "@tonaljs/chord-type";
 import { rotate, range as nums } from "@tonaljs/collection";
 import { deprecate, note, NoteName, transpose } from "@tonaljs/core";
-import { sortedUniqNames } from "@tonaljs/note";
+import { sortedUniqNames, fromMidi, enharmonic } from "@tonaljs/note";
 import { isSubsetOf, isSupersetOf, modes } from "@tonaljs/pcset";
 import {
   all as scaleTypes,
@@ -205,14 +205,17 @@ function getNoteNameOf(scale: string | string[]) {
   const chromas = names.map((name) => note(name).chroma);
 
   return (noteOrMidi: string | number): string | undefined => {
-    const height =
-      typeof noteOrMidi === "number" ? noteOrMidi : note(noteOrMidi).height;
+    const currNote =
+      typeof noteOrMidi === "number"
+        ? note(fromMidi(noteOrMidi))
+        : note(noteOrMidi);
+    const height = currNote.height;
+
     if (height === undefined) return undefined;
     const chroma = height % 12;
-    const oct = Math.floor(height / 12) - 1;
     const position = chromas.indexOf(chroma);
     if (position === -1) return undefined;
-    return names[position] + oct;
+    return enharmonic(currNote.name, names[position]);
   };
 }
 

--- a/packages/scale/test.ts
+++ b/packages/scale/test.ts
@@ -132,6 +132,20 @@ describe("@tonaljs/scale", () => {
       expect(range("g3", "a2").join(" ")).toEqual("G3 E3 D3 C3 A2");
     });
 
+    test("range of a scale name with flat", () => {
+      const range = Scale.rangeOf("Cb major");
+      expect(range("Cb4", "Cb5").join(" ")).toEqual(
+        "Cb4 Db4 Eb4 Fb4 Gb4 Ab4 Bb4 Cb5"
+      );
+    });
+
+    test("range of a scale name with sharp", () => {
+      const range = Scale.rangeOf("C# major");
+      expect(range("C#4", "C#5").join(" ")).toEqual(
+        "C#4 D#4 E#4 F#4 G#4 A#4 B#4 C#5"
+      );
+    });
+
     test("range of a scale without tonic", () => {
       const range = Scale.rangeOf("pentatonic");
       expect(range("C4", "C5")).toEqual([]);


### PR DESCRIPTION
`Scale.rangeOf` uses primitive logic to calculate the octave and doesn't take into account any octave overflows caused by accidentals. Notice how the height is non-increasing in the following example:

```
> Tonal.Scale.rangeOf('Cb major')('Cb4', 'Cb5').map(note => Tonal.Note.get(note).height)
[47, 61, 63, 64, 66, 68, 70, 59]
```

`Note.enharmonic` implements logic to calculate the correct octave, so use that to return the right note