### PR TITLE
Add support for parsing/tokenizing chord names with Unicode accidentals

### DIFF
--- a/packages/core/src/note.ts
+++ b/packages/core/src/note.ts
@@ -61,14 +61,15 @@ export function note(src: NoteLiteral): Note | NoNote {
 
 type NoteTokens = [string, string, string, string];
 
-const REGEX = /^([a-gA-G]?)(#{1,}|b{1,}|x{1,}|)(-?\d*)\s*(.*)$/;
+const REGEX = /^([a-gA-G]?)([#♯]{1,}|[b♭]{1,}|x{1,}|)(-?\d*)\s*(.*)$/;
 
 /**
  * @private
  */
 export function tokenizeNote(str: string): NoteTokens {
   const m = REGEX.exec(str) as string[];
-  return [m[1].toUpperCase(), m[2].replace(/x/g, "##"), m[3], m[4]];
+  const acc = m[2].replace(/x/g, "##").replace(/♭/g, "b").replace(/♯/g, "#");
+  return [m[1].toUpperCase(), acc, m[3], m[4]];
 }
 
 /**

--- a/packages/core/test/tonal.note.test.ts
+++ b/packages/core/test/tonal.note.test.ts
@@ -1,14 +1,23 @@
 import { note, tokenizeNote as tokenize } from "../index";
 
 describe("note", () => {
-  test("tokenize", () => {
-    expect(tokenize("Cbb5 major")).toEqual(["C", "bb", "5", "major"]);
-    expect(tokenize("Ax")).toEqual(["A", "##", "", ""]);
-    expect(tokenize("CM")).toEqual(["C", "", "", "M"]);
-    expect(tokenize("maj7")).toEqual(["", "", "", "maj7"]);
-    expect(tokenize("")).toEqual(["", "", "", ""]);
-    expect(tokenize("bb")).toEqual(["B", "b", "", ""]);
-    expect(tokenize("##")).toEqual(["", "##", "", ""]);
+  test.each([
+    ["Cbb5 major", ["C", "bb", "5", "major"]],
+    ["Ax", ["A", "##", "", ""]],
+    ["CM", ["C", "", "", "M"]],
+    ["Cm", ["C", "", "", "m"]],
+    ["maj7", ["", "", "", "maj7"]],
+    ["", ["", "", "", ""]],
+    ["bb", ["B", "b", "", ""]],
+    ["##", ["", "##", "", ""]],
+    ["A♭", ["A", "b", "", ""]],
+    ["A♭m", ["A", "b", "", "m"]],
+    ["F♯", ["F", "#", "", ""]],
+    ["F♯m", ["F", "#", "", "m"]],
+    ["b♭", ["B", "b", "", ""]],
+    ["b♭♭", ["B", "bb", "", ""]],
+  ])("tokenize(%p) should return %p", (str, tokens) => {
+    expect(tokenize(str)).toEqual(tokens);
   });
 
   describe("note properties from string", () => {


### PR DESCRIPTION
Unicode includes code points for U+266D "musical flat sign" ♭  and U+266F "musical sharp sign" ♯

This adds support for these characters when parsing chord and note names, so method calls like `Chord.get("F♯")` will return the expected result.

Note that I've explicitly not included support for Unicode double-sharp 𝄪 (U+1D12A) and double-flat 𝄫 (U+1D12B;  these characters have assigned code points above U+FFFF, and so don't work with JS regular expressions unless the /u flag is used, and that flag was only added in ES2015.