### PR TITLE
Added `export` to `interface KeyScale`

### DIFF
--- a/packages/key/index.ts
+++ b/packages/key/index.ts
@@ -18,7 +18,7 @@ const NoKey: Key = {
   keySignature: "",
 };
 
-interface KeyScale {
+export interface KeyScale {
   readonly tonic: string;
   readonly grades: readonly string[];
   readonly intervals: readonly string[];


### PR DESCRIPTION
I needed this to type `melodic`, `harmonic`, and/or `natural` Keys. 

Sorry if I am missing a way to access that type off of `<MinorKey>`.

Thanks for taking the time to review!