### PR TITLE
chore: Improve the npmjs.org package page with README and link to repo

### DIFF
--- a/packages/tonal/package.json
+++ b/packages/tonal/package.json
@@ -40,6 +40,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tonaljs/tonal.git",
+    "directory": "packages/tonal"
+  },
   "scripts": {
     "build": "npm run build:node && npm run build:browser",
     "build:node": "tsup index.ts --sourcemap --dts --format esm,cjs",

--- a/packages/tonal/package.json
+++ b/packages/tonal/package.json
@@ -10,6 +10,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "files": [
+    "README.md",
     "dist",
     "browser"
   ],


### PR DESCRIPTION
Currently the [npm package page](https://www.npmjs.com/package/tonal) is not very helpful. It doesn't render the README or have a link to the github repository.