### PR TITLE
setNumToChroma must return string of right length

### DIFF
--- a/packages/pcset/index.ts
+++ b/packages/pcset/index.ts
@@ -45,7 +45,8 @@ export type PcsetChroma = string;
 export type PcsetNum = number;
 
 // UTILITIES
-const setNumToChroma = (num: number): string => Number(num).toString(2);
+const setNumToChroma = (num: number): string =>
+  Number(num).toString(2).padStart(12, "0");
 const chromaToNumber = (chroma: string): number => parseInt(chroma, 2);
 const REGEX = /^[01]{12}$/;
 export function isChroma(set: any): set is PcsetChroma {

--- a/packages/pcset/test.ts
+++ b/packages/pcset/test.ts
@@ -19,6 +19,8 @@ describe("@tonaljs/pcset", () => {
     });
     test("from pcset number", () => {
       expect(Pcset.get(2048)).toEqual(Pcset.get(["C"]));
+      const set = Pcset.get(["D"]);
+      expect(Pcset.get(set.setNum)).toEqual(set);
     });
     test("num", () => {
       expect(Pcset.num("000000000001")).toBe(1);


### PR DESCRIPTION
Chroma isn't calculated correctly when converting from setNum. The chroma string needs to be padded with leading `0` to make it the right length. 

There is a test for this but it actually only works for the given example ("C"). I've added another (failing) test and fixed it. 

Failing test:
<img width="497" alt="image" src="https://github.com/tonaljs/tonal/assets/1696979/50f29acf-697f-4f2e-b21e-765f248cd50c">
