### PR TITLE
optimized toMidi function by 7-10 times

### DIFF
--- a/packages/chord-detect/index.ts
+++ b/packages/chord-detect/index.ts
@@ -20,9 +20,12 @@ const namedSet = (notes: string[]) => {
 };
 
 type DetectOptions = {
-  assumePerfectFifth: boolean
-}
-export function detect(source: string[], options: Partial<DetectOptions> = {}): string[] {
+  assumePerfectFifth: boolean;
+};
+export function detect(
+  source: string[],
+  options: Partial<DetectOptions> = {}
+): string[] {
   const notes = source.map((n) => note(n).pc).filter((x) => x);
   if (note.length === 0) {
     return [];
@@ -47,32 +50,41 @@ const BITMASK = {
   // 5A 000000001000
   nonPerfectFifths: 40,
   anySeventh: 3,
-}
+};
 
-const testChromaNumber = (bitmask: number) => (chromaNumber: number) => Boolean(chromaNumber & bitmask)
-const hasAnyThird = testChromaNumber(BITMASK.anyThirds)
-const hasPerfectFifth = testChromaNumber(BITMASK.perfectFifth)
-const hasAnySeventh = testChromaNumber(BITMASK.anySeventh)
-const hasNonPerfectFifth = testChromaNumber(BITMASK.nonPerfectFifths)
+const testChromaNumber = (bitmask: number) => (chromaNumber: number) =>
+  Boolean(chromaNumber & bitmask);
+const hasAnyThird = testChromaNumber(BITMASK.anyThirds);
+const hasPerfectFifth = testChromaNumber(BITMASK.perfectFifth);
+const hasAnySeventh = testChromaNumber(BITMASK.anySeventh);
+const hasNonPerfectFifth = testChromaNumber(BITMASK.nonPerfectFifths);
 
 function hasAnyThirdAndPerfectFifthAndAnySeventh(chordType: ChordType) {
-  const chromaNumber = parseInt(chordType.chroma, 2)
-  return hasAnyThird(chromaNumber) && hasPerfectFifth(chromaNumber) && hasAnySeventh(chromaNumber)
+  const chromaNumber = parseInt(chordType.chroma, 2);
+  return (
+    hasAnyThird(chromaNumber) &&
+    hasPerfectFifth(chromaNumber) &&
+    hasAnySeventh(chromaNumber)
+  );
 }
 
 function withPerfectFifth(chroma: string): string {
-  const chromaNumber = parseInt(chroma, 2)
+  const chromaNumber = parseInt(chroma, 2);
   return hasNonPerfectFifth(chromaNumber)
-  ? chroma 
-  : (chromaNumber | 16).toString(2)
+    ? chroma
+    : (chromaNumber | 16).toString(2);
 }
 
 /* tslint:enable:no-bitwise */
 
 type FindMatchesOptions = {
-  assumePerfectFifth: boolean
-}
-function findMatches(notes: string[], weight: number, options: Partial<FindMatchesOptions>): FoundChord[] {
+  assumePerfectFifth: boolean;
+};
+function findMatches(
+  notes: string[],
+  weight: number,
+  options: Partial<FindMatchesOptions>
+): FoundChord[] {
   const tonic = notes[0];
   const tonicChroma = note(tonic).chroma;
   const noteName = namedSet(notes);
@@ -81,13 +93,17 @@ function findMatches(notes: string[], weight: number, options: Partial<FindMatch
 
   const found: FoundChord[] = [];
   allModes.forEach((mode, index) => {
-    const modeWithPerfectFifth = options.assumePerfectFifth && withPerfectFifth(mode)
+    const modeWithPerfectFifth =
+      options.assumePerfectFifth && withPerfectFifth(mode);
     // some chords could have the same chroma but different interval spelling
     const chordTypes = all().filter((chordType) => {
-      if(options.assumePerfectFifth && hasAnyThirdAndPerfectFifthAndAnySeventh(chordType)) {
-        return chordType.chroma === modeWithPerfectFifth
+      if (
+        options.assumePerfectFifth &&
+        hasAnyThirdAndPerfectFifthAndAnySeventh(chordType)
+      ) {
+        return chordType.chroma === modeWithPerfectFifth;
       }
-      return chordType.chroma === mode
+      return chordType.chroma === mode;
     });
 
     chordTypes.forEach((chordType) => {

--- a/packages/chord-detect/test.ts
+++ b/packages/chord-detect/test.ts
@@ -9,12 +9,21 @@ describe("@tonal/chord-detect", () => {
   });
 
   test("assume perfect 5th", () => {
-    expect(detect(["D", "F", "C"], { assumePerfectFifth: true })).toEqual(["Dm7"]);
+    expect(detect(["D", "F", "C"], { assumePerfectFifth: true })).toEqual([
+      "Dm7",
+    ]);
     expect(detect(["D", "F", "C"], { assumePerfectFifth: false })).toEqual([]);
-    expect(detect(["D", "F", "A", "C"], { assumePerfectFifth: true })).toEqual(["Dm7", "F6/D"]);
-    expect(detect(["D", "F", "A", "C"], { assumePerfectFifth: false })).toEqual(["Dm7", "F6/D"]);
-    expect(detect(["D", "F", "Ab", "C"], { assumePerfectFifth: true })).toEqual(["Dm7b5", "Fm6/D"]);
-  })
+    expect(detect(["D", "F", "A", "C"], { assumePerfectFifth: true })).toEqual([
+      "Dm7",
+      "F6/D",
+    ]);
+    expect(detect(["D", "F", "A", "C"], { assumePerfectFifth: false })).toEqual(
+      ["Dm7", "F6/D"]
+    );
+    expect(detect(["D", "F", "Ab", "C"], { assumePerfectFifth: true })).toEqual(
+      ["Dm7b5", "Fm6/D"]
+    );
+  });
 
   test("(regression) detect aug", () => {
     expect(detect(["C", "E", "G#"])).toEqual(["Caug", "Eaug/C", "G#aug/C"]);

--- a/packages/midi/index.ts
+++ b/packages/midi/index.ts
@@ -9,23 +9,61 @@ export function isMidi(arg: any): arg is Midi {
 /**
  * Get the note midi number (a number between 0 and 127)
  *
- * It returns undefined if not valid note name
+ * It returns null if not valid note name
  *
  * @function
- * @param {string|number} note - the note name or midi number
+ * @param {string} input - the note name or midi number
  * @return {Integer} the midi number or undefined if not valid note
  * @example
  * import { toMidi } from '@tonaljs/midi'
  * toMidi("C4") // => 60
- * toMidi(60) // => 60
- * toMidi('60') // => 60
  */
-export function toMidi(note: NoteName | number): number | null {
-  if (isMidi(note)) {
-    return +note;
+export function toMidi(input: string): number | null {
+  if (input.length > 5) return null;
+
+  // check if octave is a number
+  let octave = input.charCodeAt(input.length - 1) - 48;
+  if (octave < 0 || octave > 9) return null;
+
+  // toLowerCase but for the first char only
+  const ch = input.charCodeAt(0) + +(input.charCodeAt(0) < 97) * 32;
+
+  // Check if first letter is in range of a - g
+  if (ch < 97 || ch > 103) return null;
+
+  let note = 0;
+  if (input.length > 2) {
+    if (input.charAt(1) === "#") note++;
+    else if (input.charAt(1) === "b") note--;
+    else if (input.charAt(1) !== "-") return null;
   }
-  const n = props(note);
-  return n.empty ? null : n.midi;
+  if (input.length > 3) {
+    // this is mundane but it's faster than using .slice()
+    if (input.charAt(1) === "#" && input.charAt(2) === "#") note++;
+    else if (input.charAt(1) === "b" && input.charAt(2) === "b") note--;
+    else if (input.charAt(2) !== "-") return null;
+  }
+
+  // check if the input is valid
+  if (input.charAt(input.length - 2) === "-") {
+    if (input.charAt(input.length - 1) !== "1") return null;
+    octave = -1;
+  }
+
+  // (note - 97 - 2 + 7) set the note number acordingly to each letter
+  // with a -2 shift so "c" = 0 "d" = 1 ... "b" = 11
+  const notePre = (ch - 92) % 7;
+
+  // multiply by 2 because sharps
+  // subtract 1 if note is higher than D
+  // const note = notePre * 2 - (notePre > 2 ? 1 : 0)
+  note += notePre * 2 - (notePre > 2 ? 1 : 0);
+
+  // add everything toghether
+  const tone = 12 + octave * 12 + note;
+
+  if (tone < 0 || tone > 127) return null;
+  return tone;
 }
 
 /**

--- a/packages/midi/test.ts
+++ b/packages/midi/test.ts
@@ -6,15 +6,33 @@ describe("midi", () => {
   });
 
   test("toMidi", () => {
-    expect(Midi.toMidi(100)).toBe(100);
     expect(Midi.toMidi("C4")).toBe(60);
-    expect(Midi.toMidi("60")).toBe(60);
-    expect(Midi.toMidi(0)).toBe(0);
-    expect(Midi.toMidi("0")).toBe(0);
-    expect(Midi.toMidi(-1)).toBe(null);
-    expect(Midi.toMidi(128)).toBe(null);
-    expect(Midi.toMidi("blah")).toBe(null);
-    expect(Midi.toMidi(NaN)).toBe(null);
+    expect(Midi.toMidi("D5")).toBe(74);
+    expect(Midi.toMidi("D#5")).toBe(75);
+    expect(Midi.toMidi("G#2")).toBe(44);
+    expect(Midi.toMidi("F#3")).toBe(54);
+    expect(Midi.toMidi("A#6")).toBe(94);
+    expect(Midi.toMidi("B1")).toBe(35);
+    expect(Midi.toMidi("E6")).toBe(88);
+    expect(Midi.toMidi("Cb2")).toBe(35);
+    expect(Midi.toMidi("D##4")).toBe(64);
+    expect(Midi.toMidi("Abb3")).toBe(55);
+    expect(Midi.toMidi("b0")).toBe(23);
+    expect(Midi.toMidi("f-1")).toBe(5);
+    expect(Midi.toMidi("gb-1")).toBe(6);
+    expect(Midi.toMidi("a##-1")).toBe(11);
+    expect(Midi.toMidi("g#9")).toBe(null);
+    expect(Midi.toMidi("a##9")).toBe(null);
+    expect(Midi.toMidi("gb#1")).toBe(null);
+    expect(Midi.toMidi("g##-2")).toBe(null);
+    expect(Midi.toMidi("cbb-1")).toBe(null);
+    expect(Midi.toMidi("CC")).toBe(null);
+    expect(Midi.toMidi("X5")).toBe(null);
+    expect(Midi.toMidi("G#")).toBe(null);
+    expect(Midi.toMidi("H5")).toBe(null);
+    expect(Midi.toMidi("G44")).toBe(null);
+    expect(Midi.toMidi("Hello World!")).toBe(null);
+    expect(Midi.toMidi("V7")).toBe(null);
   });
 
   test("freqToMidi", () => {

--- a/packages/mode/index.ts
+++ b/packages/mode/index.ts
@@ -14,7 +14,7 @@ const MODES = [
   [6, 3434, 5, "locrian", "dim", "m7b5"],
 ] as const;
 
-type ModeDatum = typeof MODES[number];
+type ModeDatum = (typeof MODES)[number];
 
 export interface Mode extends Pcset {
   readonly name: string;


### PR DESCRIPTION
i made toMidi() function much faster but, at the cost of not having numbers and stringified numbers as input.
so these test cases will fail:
```ts
expect(Midi.toMidi("60")).toBe(60);
expect(Midi.toMidi(60)).toBe(60);
```
benchmarks were made on a [separate repository](https://github.com/eye-wave/fast-note-parser)
```
my-parser: [MIN] 5.63 ms
my-parser: [MAX] 25.37 ms
my-parser: [AVG] 15.82 ms

tonal-midi: [MIN] 140.65 ms
tonal-midi: [MAX] 176.28 ms
tonal-midi: [AVG] 150.44 ms
```

also i'm sorry for that messy commit diff, i thought it was formatted and linted beforehand