### PR TITLE
Fix README for key package

### DIFF
--- a/packages/key/README.md
+++ b/packages/key/README.md
@@ -23,8 +23,8 @@ const { Key } = require("tonal");
 Tonics of any key are represented with pitch classes (octaves are discarded).
 
 ```js
-Key.major("C4"); // is equal to
-Key.major("C");
+Key.majorKey("C4"); // is equal to
+Key.majorKey("C");
 ```
 
 #### `majorKey(tonic: string) => MajorKey`


### PR DESCRIPTION
I spotted an issue with a couple lines of the README for the keys package. `Key.major` is not a function, so I've updated the lines in question to use the correct function call of `Key.majorKey`. Hopefully this small modifcation will help other developers avoid a short moment of confusion.

Basing this onto the main branch but understand if you want it to go into a different branch, rebase as you desire...