### PR TITLE
chore: update eharmonic examples

### DIFF
--- a/packages/note/README.md
+++ b/packages/note/README.md
@@ -202,6 +202,15 @@ Given a note name, returns its enharmonic (or "" if not valid note):
 Note.enharmonic("C#"); // => "Db"
 Note.enharmonic("C##"); // => "D"
 Note.enharmonic("C###"); // => "Eb"
+
+Note.eharmoinic("C##b"); // => ""
+```
+
+Using eharmonic on a natural will return the same value passed in:
+
+```js
+Note.eharmonic("C"); // => "C"
+Note.eharmonic("C4"); // => "C4"
 ```
 
 The destination pitch class can be enforced to calculate the octave:

--- a/packages/note/index.ts
+++ b/packages/note/index.ts
@@ -234,6 +234,7 @@ export const simplify = (noteName: NoteName | Pitch): string => {
  * Note.enharmonic("Db") // => "C#"
  * Note.enharmonic("C") // => "C"
  * Note.enharmonic("F2","E#") // => "E#2"
+ * Note.eharmoinic("C##b"); // => ""
  */
 export function enharmonic(noteName: string, destName?: string) {
   const src = get(noteName);


### PR DESCRIPTION
Was using eharmonic in my project, and needed to know what would happen on natural notes, it wasn't in the docs so I had to go through and console.log() the results my self and see.

Figured I'd update the docs with what I wanted to know to save anyone with the same problem in the future some time.
Decided to also add a code example of eharmonic returning "" to the readme since it was in the comment of the method itself.