### PR TITLE
Fix speling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ abstractions (not actual music or sound).
 `tonal` is implemented in Typescript and published as a collection of Javascript
 npm packages.
 
-It uses a functional programing style: all functions are pure, there is no data
+It uses a functional programming style: all functions are pure, there is no data
 mutation, and entities are represented by data structures instead of objects.
 
 ## Example

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -94,12 +94,12 @@ TODO: diagram of tonal modules
 
 Lot of changes, but as a positive side effect, the library API surface is smaller so code and documentation are easier to write and maintain.
 
-Now functions falls in two catergories:
+Now functions falls in two categories:
 
 - **Parsers**: takes a name of something (string) and return an object with properties. Examples of that functions are: note, interval, pcset, scaleType, chordType, scale, chord, mode. All of the returning objects has the properties `empty` (boolean) and name (string, "" indicating _no value_)
 - **Operations**: takes one or more names and return a new name. It always work with strings (no objects). Invalid results are represented with empty strings "". Examples: transpose, distance, subtract
 
-### Utilility functions removed or made private
+### Utility functions removed or made private
 
 First of all, lot of functions are gone, like `oct`, `accToAlt`, and other utility functions (some still exists, but are considered private)
 
@@ -118,7 +118,7 @@ This optional partial application made code unnecessarily complex and, with Type
 
 For this reason **optional** partial application are not possible in v3. Most of the functions needs all parameters to execute.
 
-However, there are some execptions to make the API easier to use. In that cases, partial application is obligatory:
+However, there are some exceptions to make the API easier to use. In that cases, partial application is obligatory:
 
 ```js
 // valid in v2 and v3

--- a/packages/array/index.ts
+++ b/packages/array/index.ts
@@ -32,7 +32,7 @@ export function range(from: number, to: number): number[] {
 }
 
 /**
- * Rotates a list a number of times. It"s completly agnostic about the
+ * Rotates a list a number of times. It's completely agnostic about the
  * contents of the list.
  *
  * @param {Integer} times - the number of rotations

--- a/packages/collection/index.ts
+++ b/packages/collection/index.ts
@@ -30,7 +30,7 @@ export function range(from: number, to: number): number[] {
 }
 
 /**
- * Rotates a list a number of times. It"s completly agnostic about the
+ * Rotates a list a number of times. It's completely agnostic about the
  * contents of the list.
  *
  * @param {Integer} times - the number of rotations

--- a/packages/core/test/tonal.transpose.test.ts
+++ b/packages/core/test/tonal.transpose.test.ts
@@ -17,7 +17,7 @@ describe("Transpose", () => {
       expect(fromBb2("P1 M3 P5 M7")).toEqual(["Bb2", "D3", "F3", "A3"]);
     });
 
-    test("tranpose note by descending intervas", () => {
+    test("transpose note by descending intervals", () => {
       const fromBb = transposeAllFrom("Bb");
       expect(fromBb("P-1 M-3 P-5 M-7")).toEqual(["Bb", "Gb", "Eb", "Cb"]);
     });

--- a/packages/interval/README.md
+++ b/packages/interval/README.md
@@ -103,7 +103,7 @@ Interval.add("3m", "5P"); // => "7m"
 
 #### `subtract(min: string, sub: string) => string`
 
-Substract two intervals:
+Subtract two intervals:
 
 ```js
 subtract("5P", "3M"); // => '3m'

--- a/packages/key/index.ts
+++ b/packages/key/index.ts
@@ -307,7 +307,7 @@ export function minorKey(tnc: string): MinorKey {
 
 /**
  * Given a key signature, returns the tonic of the major key
- * @param sigature
+ * @param signature
  * @example
  * majorTonicFromKeySignature('###') // => 'A'
  */

--- a/packages/midi/index.ts
+++ b/packages/midi/index.ts
@@ -30,7 +30,7 @@ export function toMidi(note: NoteName | number): number | null {
 }
 
 /**
- * Get the frequency in hertzs from midi number
+ * Get the frequency in hertz from midi number
  *
  * @param {number} midi - the note midi number
  * @param {number} [tuning = 440] - A4 tuning frequency in Hz (440 by default)

--- a/packages/mode/index.ts
+++ b/packages/mode/index.ts
@@ -20,7 +20,7 @@ type ModeDatum = (typeof MODES)[number];
 export interface Mode extends Pcset {
   readonly name: string;
   readonly modeNum: number;
-  readonly alt: number; // number of alterations === number of fiths
+  readonly alt: number; // number of alterations === number of fifths
   readonly triad: string;
   readonly seventh: string;
   readonly aliases: string[];

--- a/packages/note/README.md
+++ b/packages/note/README.md
@@ -108,7 +108,7 @@ Note.transpose("d3", "3M"); // => "F#3"
 Note.transpose("D", "3M"); // => "F#"
 ```
 
-`transposeBy` and `transposeFrom` are currified versions of this function to make easy work with arrays:
+`transposeBy` and `transposeFrom` are curried versions of this function to make easy work with arrays:
 
 ```js
 ["C", "D", "E"].map(Note.transposeBy("5P"));
@@ -209,14 +209,14 @@ Note.enharmonic("C#"); // => "Db"
 Note.enharmonic("C##"); // => "D"
 Note.enharmonic("C###"); // => "Eb"
 
-Note.eharmoinic("C##b"); // => ""
+Note.enharmonic("C##b"); // => ""
 ```
 
-Using eharmonic on a natural will return the same value passed in:
+Using enharmonic on a natural will return the same value passed in:
 
 ```js
-Note.eharmonic("C"); // => "C"
-Note.eharmonic("C4"); // => "C4"
+Note.enharmonic("C"); // => "C"
+Note.enharmonic("C4"); // => "C4"
 ```
 
 The destination pitch class can be enforced to calculate the octave:

--- a/packages/note/index.ts
+++ b/packages/note/index.ts
@@ -162,7 +162,7 @@ export const trFrom = transposeFrom;
  *
  * @function
  * @param {string} note - the note name
- * @param {number} fifhts - the number of fifths
+ * @param {number} fifths - the number of fifths
  * @return {string} the transposed note name
  *
  * @example
@@ -236,7 +236,7 @@ export const simplify = (noteName: NoteName | Pitch): string => {
  * Note.enharmonic("Db") // => "C#"
  * Note.enharmonic("C") // => "C"
  * Note.enharmonic("F2","E#") // => "E#2"
- * Note.eharmoinic("C##b"); // => ""
+ * Note.enharmonic("C##b"); // => ""
  */
 export function enharmonic(noteName: string, destName?: string) {
   const src = get(noteName);

--- a/packages/pcset/README.md
+++ b/packages/pcset/README.md
@@ -79,7 +79,7 @@ Pcset.notes("101011010110"); // => ["C", "D", "E", "F", "G", "A", "Bb"]
 
 ### `isIncludedIn(parent: Set) => (note: string) => boolean`
 
-Test if a note is included in the given set. This function is currified:
+Test if a note is included in the given set. This function is curried:
 
 ```js
 const isInCTriad = isNoteIncludedIn(["C", "E", "G"]);
@@ -95,11 +95,11 @@ isInCTriad("Fb"); // => true
 
 #### `isSubsetOf(parent: Set) => (subset: Set) => boolean`
 
-Test if a set is a subset of another. This function is currified
+Test if a set is a subset of another. This function is curried
 
 #### `isSupersetOf(subset: Set) => (parent: Set) => boolean`
 
-Test if a set is a superset of another. This function is currified
+Test if a set is a superset of another. This function is curried
 
 ## Want more?
 

--- a/packages/pcset/index.ts
+++ b/packages/pcset/index.ts
@@ -7,7 +7,7 @@ import { Note, NoteName, note } from "@tonaljs/pitch-note";
 /**
  * The properties of a pitch class set
  * @param {number} num - a number between 1 and 4095 (both included) that
- * uniquely identifies the set. It's the decimal number of the chrom.
+ * uniquely identifies the set. It's the decimal number of the chroma.
  * @param {string} chroma - a string representation of the set: a 12-char string
  * with either "1" or "0" as characters, representing a pitch class or not
  * for the given position in the octave. For example, a "1" at index 0 means 'C',
@@ -209,7 +209,7 @@ export function isEqual(s1: Set, s2: Set) {
  * Create a function that test if a collection of notes is a
  * subset of a given set
  *
- * The function is curryfied.
+ * The function is curried.
  *
  * @param {PcsetChroma|NoteName[]} set - the superset to test against (chroma or
  * list of notes)

--- a/packages/range/README.md
+++ b/packages/range/README.md
@@ -44,7 +44,7 @@ Create a range of chromatic notes. The same as `numeric` but the result will be 
 The optional `options` object defines how note names are built:
 
 - sharps: if `true` sharps will be used in altered notes. Default is `false`
-- pitchClass: if `true` octaves are omited. Default is `false`
+- pitchClass: if `true` octaves are omitted. Default is `false`
 
 ```js
 Range.chromatic(["C2", "E2", "D2"]);

--- a/packages/roman-numeral/README.md
+++ b/packages/roman-numeral/README.md
@@ -2,7 +2,7 @@
 
 > Functions to parse roman numeral strings (like the ones used for chord analysis)
 
-A roman numeral symbol is a string like `"bVIImaj7"` that can be used to represent chords in an abstract tonallity.
+A roman numeral symbol is a string like `"bVIImaj7"` that can be used to represent chords in an abstract tonality.
 
 ## Usage
 

--- a/packages/scale/index.ts
+++ b/packages/scale/index.ts
@@ -49,15 +49,15 @@ const NoScale: Scale = {
  * Given a string with a scale name and (optionally) a tonic, split
  * that components.
  *
- * It retuns an array with the form [ name, tonic ] where tonic can be a
+ * It returns an array with the form [ name, tonic ] where tonic can be a
  * note name or null and name can be any arbitrary string
- * (this function doesn"t check if that scale name exists)
+ * (this function doesn't check if that scale name exists)
  *
  * @function
  * @param {string} name - the scale name
  * @return {Array} an array [tonic, name]
  * @example
- * tokenize("C mixolydean") // => ["C", "mixolydean"]
+ * tokenize("C mixolydian") // => ["C", "mixolydian"]
  * tokenize("anything is valid") // => ["", "anything is valid"]
  * tokenize() // => ["", ""]
  */

--- a/packages/tonal/README.md
+++ b/packages/tonal/README.md
@@ -12,7 +12,7 @@ abstractions (not actual music or sound).
 `tonal` is implemented in Typescript and published as a collection of Javascript
 npm packages.
 
-It uses a functional programing style: all functions are pure, there is no data
+It uses a functional programming style: all functions are pure, there is no data
 mutation, and entities are represented by data structures instead of objects.
 
 ## Example

--- a/site/content/docs/basics/intervals.md
+++ b/site/content/docs/basics/intervals.md
@@ -123,7 +123,7 @@ Interval.add("3m", "5P"); // => "7m"
 
 `subtract(min: string, sub: string) => string`
 
-Substract two intervals:
+Subtract two intervals:
 
 ```js
 subtract("5P", "3M"); // => '3m'

--- a/site/content/docs/basics/notes.md
+++ b/site/content/docs/basics/notes.md
@@ -108,7 +108,7 @@ Note.transpose("d3", "3M"); // => "F#3"
 Note.transpose("D", "3M"); // => "F#"
 ```
 
-`transposeBy` and `transposeFrom` are currified versions of this function to make easy work with arrays:
+`transposeBy` and `transposeFrom` are curried versions of this function to make easy work with arrays:
 
 ```js
 ["C", "D", "E"].map(Note.transposeBy("5P"));

--- a/site/content/docs/groups/pitch-class-sets.md
+++ b/site/content/docs/groups/pitch-class-sets.md
@@ -83,7 +83,7 @@ Pcset.notes("101011010110"); // => ["C", "D", "E", "F", "G", "A", "Bb"]
 
 `isIncludedIn(parent: Set) => (note: string) => boolean`
 
-Test if a note is included in the given set. This function is currified:
+Test if a note is included in the given set. This function is curried:
 
 ```js
 const isInCTriad = isIncludedIn(["C", "E", "G"]);
@@ -101,10 +101,10 @@ isInCTriad("Fb"); // => true
 
 `isSubsetOf(parent: Set) => (subset: Set) => boolean`
 
-Test if a set is a subset of another. This function is currified
+Test if a set is a subset of another. This function is curried
 
 ### `Pcset.isSupersetOf`
 
 `isSupersetOf(subset: Set) => (parent: Set) => boolean`
 
-Test if a set is a superset of another. This function is currified
+Test if a set is a superset of another. This function is curried

--- a/site/content/docs/index.md
+++ b/site/content/docs/index.md
@@ -11,7 +11,7 @@ abstractions (not actual music or sound).
 `tonal` is implemented in Typescript and published as a collection of Javascript
 npm packages.
 
-It uses a functional programing style: all functions are pure, there is no data
+It uses a functional programming style: all functions are pure, there is no data
 mutation, and entities are represented by data structures instead of objects.
 
 ## Example

--- a/site/content/docs/utils/ranges.md
+++ b/site/content/docs/utils/ranges.md
@@ -29,7 +29,7 @@ Create a range of chromatic notes. The same as `numeric` but the result will be 
 The optional `options` object defines how note names are built:
 
 - sharps: if `true` sharps will be used in altered notes. Default is `false`
-- pitchClass: if `true` octaves are omited. Default is `false`
+- pitchClass: if `true` octaves are omitted. Default is `false`
 
 ```js
 Range.chromatic(["C2", "E2", "D2"]);


### PR DESCRIPTION
There were a couple of typos in the project which I've addressed, but I made sure not to change intentional misspellings, such as in the migration guide where it says "tranpose" on purpose.