### PR TITLE
fix broken links and add project using Tonal

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Showcase of projects that are using Tonal:
 - [music, eternal](https://eternal.rob.computer) by [kousun12](https://github.com/kousun12)
 - [Chromatone.center](https://chromatone.center) by [davay42](https://github.com/davay42)
 - [Super Oscillator](https://github.com/lukehorvat/super-oscillator) by [lukehorvat](https://github.com/lukehorvat)
-  [StringScales](https://stringscales.com/) by [Ambewas](https://github.com/ambewas)
+- [StringScales](https://stringscales.com/) by [Ambewas](https://github.com/ambewas)
+- [Polychron](https://github.com/PolychronMidi/Polychron) by [i1li](https://github.com/i1li)
 
 Thank you all!
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ This library takes inspiration from other music theory libraries:
 - Teoria: https://github.com/saebekassebil/teoria
 - Impro-Visor: https://www.cs.hmc.edu/~keller/jazz/improvisor/
 - MusicKit: https://github.com/benzguo/MusicKit
-- Music21: http://web.mit.edu/music21/doc/index.html
+- Music21: https://www.music21.org/music21docs/
 - Sharp11: https://github.com/jsrmath/sharp11
 - python-mingus: https://github.com/bspaans/python-mingus
+- Open Music Theory: https://viva.pressbooks.pub/openmusictheory/
 
 ## Projects using tonal
 

--- a/packages/voice-leading/README.md
+++ b/packages/voice-leading/README.md
@@ -1,6 +1,6 @@
 # @tonaljs/voice-leading
 
-Contains a collection functions to find optimal transitions between chord voicings. Used by [@tonaljs/voicings](../voicings).
+Contains a collection of functions to find optimal transitions between chord voicings. Used by [@tonaljs/voicing](../voicing).
 
 ## Usage
 
@@ -60,4 +60,4 @@ topNoteDiff(
 
 [show available voice leading functions](./index.ts).
 
-See [@tonaljs/voicings](../voicings) for usage examples.
+See [@tonaljs/voicing](../voicing) for usage examples.

--- a/packages/voicing-dictionary/README.md
+++ b/packages/voicing-dictionary/README.md
@@ -1,6 +1,6 @@
 # @tonaljs/voicing-dictionary
 
-Contains dictionaries for many chord voicings. Used by [@tonaljs/voicings](../voicings).
+Contains dictionaries for many chord voicings. Used by [@tonaljs/voicing](../voicing).
 
 ## Usage
 
@@ -41,4 +41,4 @@ const lefthand = {
 
 [show available dictionaries](./data.ts).
 
-See [@tonaljs/voicings](../voicings) for usage examples.
+See [@tonaljs/voicing](../voicing) for usage examples.

--- a/site/content/docs/voicings/dictionary.md
+++ b/site/content/docs/voicings/dictionary.md
@@ -4,7 +4,7 @@ title: Voicing dictionary
 
 `@tonaljs/voicing-dictionary`
 
-Contains dictionaries for many chord voicings. Used by [@tonaljs/voicings](../voicings).
+Contains dictionaries for many chord voicings. Used by [@tonaljs/voicing](../voicing).
 
 ## Usage
 
@@ -43,4 +43,4 @@ const lefthand = {
 };
 ```
 
-See [@tonaljs/voicings](../voicings) for usage examples.
+See [@tonaljs/voicing](../voicing) for usage examples.

--- a/site/content/docs/voicings/leading.md
+++ b/site/content/docs/voicings/leading.md
@@ -4,7 +4,7 @@ title: Voice leading
 
 `@tonaljs/voice-leading`
 
-Contains a collection functions to find optimal transitions between chord voicings.
+Contains a collection of functions to find optimal transitions between chord voicings.
 
 ## Usage
 


### PR DESCRIPTION
add project using Tonal

fix broken links that went to @tonaljs/voicings instead of @tonaljs/voicing

fix broken link to music21 in main README, and added link to Open Music Theory under 'inspiration'