### PR TITLE
Fix broken README.md rendering

### DIFF
--- a/packages/scale/README.md
+++ b/packages/scale/README.md
@@ -72,13 +72,12 @@ Scale.detect(["C", "D", "E", "F", "G", "A", "B"], { tonic: "A" });
 
 You can ask just the exact match:
 
-````js
+```js
 Scale.detect(["D", "E", "F#", "A", "B"], { match: "exact" });
 // => ["D major pentatonic"]
 Scale.detect(["D", "E", "F#", "A", "B"], { match: "exact", tonic: "B" });
 // => ["B major pentatonic"]
 ```
-
 
 ### `Scale.scaleChords(scale: string) => string[]`
 


### PR DESCRIPTION
There was an extra backtick, which caused the following JS block to incorrectly be merged with that JS block. Highlighted below:

![IMG_6857](https://github.com/user-attachments/assets/a862af8a-cff5-49cd-b4fb-4181d6e1f6e5)
