### PR TITLE
Fix: Midi pcsetNearest not taking octave displacement into account

### DIFF
--- a/packages/midi/index.ts
+++ b/packages/midi/index.ts
@@ -133,8 +133,10 @@ export function pcsetNearest(notes: number[] | string) {
   return (midi: number): number | undefined => {
     const ch = chroma(midi);
     for (let i = 0; i < 12; i++) {
-      if (set.includes(ch + i)) return midi + i;
-      if (set.includes(ch - i)) return midi - i;
+      const chUp = (ch + i) % 12;
+      const chDown = (ch - i + 12) % 12;
+      if (set.includes(chUp)) return midi + i;
+      if (set.includes(chDown)) return midi - i;
     }
     return undefined;
   };

--- a/packages/midi/test.ts
+++ b/packages/midi/test.ts
@@ -58,7 +58,14 @@ describe("midi", () => {
     test("find nearest upwards", () => {
       const nearest = Midi.pcsetNearest([0, 5, 7]);
       expect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(nearest)).toEqual([
-        0, 0, 0, 5, 5, 5, 7, 7, 7, 7, 7, 7, 12,
+        0, 0, 0, 5, 5, 5, 7, 7, 7, 7, 12, 12, 12,
+      ]);
+    });
+
+    test("chromatic to nearest C minor pentatonic", () => {
+      const nearest = Midi.pcsetNearest("100101010010");
+      expect([36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47].map(nearest)).toEqual([
+        36, 36, 39, 39, 41, 41, 43, 43, 43, 46, 46, 48
       ]);
     });
 

--- a/packages/midi/test.ts
+++ b/packages/midi/test.ts
@@ -69,6 +69,13 @@ describe("midi", () => {
       ]);
     });
 
+    test("chromatic to nearest half octave", () => {
+      const nearest = Midi.pcsetNearest("100000100000");
+      expect([36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47].map(nearest)).toEqual([
+        36, 36, 36, 42, 42, 42, 42, 42, 42, 48, 48, 48
+      ]);
+    })
+
     test("empty pcsets returns the note", () => {
       expect([10, 30, 40].map(Midi.pcsetNearest([]))).toEqual([]);
     });


### PR DESCRIPTION
I noticed a small bug with the pcsetNearest function in the Midi package. The issue is with the following code:

```
if (set.includes(ch + i)) return midi + i;
if (set.includes(ch - i)) return midi - i;
```

The problem here is that in certain situations `ch + i` could be greater than 11, or `ch - i` could be lower than 0. For an extreme example that demonstrates the issue, consider mapping the chromatic scale to a pcset of just a C and F# (i.e. 100000100000).

```
const nearest = Midi.pcsetNearest("100000100000");
[36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47].map(nearest);
```

With the old algorithm, this would give the following output:

```
[36, 36, 36, 42, 42, 42, 42, 42, 42, 42, 42, 42]
```

However, this is clearly wrong. The B natural (midi 47) is closer to a C than an F#, but is marked as being closest to the F#. This is because `ch + i` will be greater than 12 for any value of `i > 0`, but the pcset only includes chromas between 0 and 11. This causes subtler issues with more real-world examples. For example, consider mapping the chromatic scale to the nearest C minor pentatonic scale.  The B natural will be marked as being nearest to the Bb (rather than C). While B natural is equidistant from Bb and C, the algorithm usually prefers the higher pitch in equidistant scenarios.

To fix this, I have modified the pcsetNearest algorithm to take into account octave displacement. I have also modified the tests, and added a few demonstrating the issue to take this into account. I think it might also make sense to add a boolean flag to the function `preferHigherPitchWhenEquidistant`, but I'll leave that for a separate PR.
