### PR TITLE
Fixed #469

### DIFF
--- a/site/content/docs/groups/scales.md
+++ b/site/content/docs/groups/scales.md
@@ -159,7 +159,7 @@ You can ask just the exact match:
 Scale.detect(["D", "E", "F#", "A", "B"], { match: "exact" });
 // => ["D major pentatonic"]
 Scale.detect(["D", "E", "F#", "A", "B"], { match: "exact", tonic: "B" });
-// => ["B major pentatonic"]
+// => ["B minor pentatonic"]
 ```
 
 ## Relationships


### PR DESCRIPTION
This is indeed mistake in docs:

`Scale.detect(["D", "E", "F#", "A", "B"], { match: "exact", tonic: "B" })`
returns "B minor pentatonic"
but in docs, it says "B major pentatonic".