### PR TITLE
docs: fix incorrect output values in package README examples

### DIFF
--- a/packages/pcset/README.md
+++ b/packages/pcset/README.md
@@ -54,17 +54,17 @@ Several shorthands (`num`, `chroma`, intervals`) are provided:
 
 ```js
 Pcset.chroma(["c", "d", "e"]); //=> "101010000000"
-Pcset.num(["c", "d", "e"]); //=> 2192
+Pcset.num(["c", "d", "e"]); //=> 2688
 
 // several set representations are accepted
-Pcset.chroma(2192); //=> "101010000000"
-Pcset.num("101010000000"); // => 2192
+Pcset.chroma(2688); //=> "101010000000"
+Pcset.num("101010000000"); // => 2688
 ```
 
 Intervals are always calculated from `C`:
 
 ```js
-Pcset.intervals(["c", "d", "e"]); // => ["1P", "5P", "7M"]
+Pcset.intervals(["c", "d", "e"]); // => ["1P", "2M", "3M"]
 Pcset.intervals(["D", "F", "A"]); // => ["2M", "4P", "6M"]
 ```
 

--- a/packages/scale-type/README.md
+++ b/packages/scale-type/README.md
@@ -76,8 +76,8 @@ ScaleType.all()
 
 ```js
 ScaleType.add(["1P", "5P"], "quinta", ["quinta justa", "diapente"]);
-ScaleType.scale("quinta"); // => { name: "quinta", intervals: ...}
-ScaleType.scale("quinta justa"); // => { name: "quinta", intervals: ... }
+ScaleType.get("quinta"); // => { name: "quinta", intervals: ...}
+ScaleType.get("quinta justa"); // => { name: "quinta", intervals: ... }
 ```
 
 #### References

--- a/packages/tonal/README.md
+++ b/packages/tonal/README.md
@@ -20,8 +20,8 @@ mutation, and entities are represented by data structures instead of objects.
 ```js
 import { Interval, Note, Scale } from "tonal";
 
-Note.midi("A4"); // => 60
-Note.freq("a4").freq; // => 440
+Note.midi("A4"); // => 69
+Note.freq("A4"); // => 440
 Note.accidentals("c#2"); // => '#'
 Note.transpose("C4", "5P"); // => "G4"
 Interval.semitones("5P"); // => 7


### PR DESCRIPTION
## What was wrong

Several README code examples across the `tonal` monorepo printed outputs that don't match the actual behavior of the published `tonal` npm package. Every corrected value below was verified by running the exact snippet against the installed `tonal@6.4.3` package (matching this repo's current HEAD).

- `packages/tonal/README.md`: `Note.midi("A4")` was documented as `60`; A4 is actually MIDI note `69`. `Note.freq("a4").freq` chained `.freq` onto a number (`Note.freq` returns a plain number), which is `undefined`; fixed to `Note.freq("A4") // => 440`.
- `packages/pcset/README.md`: the `Pcset.num` / `Pcset.chroma` round-trip examples documented set number `2192`, but the actual set number for `["c","d","e"]` / chroma `"101010000000"` is `2688` (this also matches the `Pcset.get()` example earlier in the same file, which already showed the correct `2688`). Also, `Pcset.intervals(["c","d","e"])` was documented as `["1P","5P","7M"]`; the actual result is `["1P","2M","3M"]`.
- `packages/scale-type/README.md`: the "how to add a scale" example called `ScaleType.scale(...)`, which does not exist on the module; corrected to the real API, `ScaleType.get(...)`.

`packages/interval/README.md` was intentionally left untouched since there's an existing open docs PR (#486) covering that file. `packages/chord-type/README.md`'s `Chord.detect` example was re-checked and found to already be correct as documented, so no change was needed there.

## Notes

Happy to split into separate PRs per package if preferred.
