### PR TITLE
Wrap regex in non-capturing group to reject malformed intervals

### DIFF
--- a/packages/pitch-interval/index.ts
+++ b/packages/pitch-interval/index.ts
@@ -58,7 +58,7 @@ const INTERVAL_TONAL_REGEX = "([-+]?\\d+)(d{1,4}|m|M|P|A{1,4})";
 // standard shorthand notation (with quality before number)
 const INTERVAL_SHORTHAND_REGEX = "(AA|A|P|M|m|d|dd)([-+]?\\d+)";
 const REGEX = new RegExp(
-  "^" + INTERVAL_TONAL_REGEX + "|" + INTERVAL_SHORTHAND_REGEX + "$",
+  "^(?:" + INTERVAL_TONAL_REGEX + "|" + INTERVAL_SHORTHAND_REGEX + ")$",
 );
 
 type IntervalTokens = [string, string];

--- a/packages/pitch-interval/test.ts
+++ b/packages/pitch-interval/test.ts
@@ -46,6 +46,17 @@ describe("interval", () => {
       expect(interval("not-an-interval").empty).toEqual(true);
       expect(interval("2P").empty).toBe(true);
     });
+
+    test("rejects malformed intervals", () => {
+      expect(interval("ddd5").empty).toBe(true);
+      expect(interval("AAA5").empty).toBe(true);
+      expect(interval("garbageP5").empty).toBe(true);
+      expect(interval("5Pgarbage").empty).toBe(true);
+      expect(tokenize("ddd5")).toEqual(["", ""]);
+      expect(tokenize("AAA5")).toEqual(["", ""]);
+      expect(tokenize("garbageP5")).toEqual(["", ""]);
+      expect(tokenize("5Pgarbage")).toEqual(["", ""]);
+    });
     test("q", () => {
       const q = (str: string) => str.split(" ").map((i) => interval(i).q);
       expect(q("1dd 1d 1P 1A 1AA")).toEqual(["dd", "d", "P", "A", "AA"]);


### PR DESCRIPTION
closes #494 

Fix for interval shorthand regex parsing invalid strings