### PR TITLE
fix(time-signature): return NONE instead of throwing on non-matching input

### DIFF
--- a/packages/time-signature/index.ts
+++ b/packages/time-signature/index.ts
@@ -69,6 +69,13 @@ export function parse(literal: TimeSignatureLiteral): ParsedTimeSignature {
     return [up, denominator];
   }
 
+  // Guard against input that does not match REGEX (e.g. "C"): the exec above
+  // yields an undefined `up`, so `up.split` would throw. Return a zeroed parse
+  // that `build` maps to the NONE signature, matching invalid inputs like "0/0".
+  if (typeof up !== "string") {
+    return [0, 0];
+  }
+
   const list = up.split("+").map((n) => +n);
   return list.length === 1 ? [list[0], denominator] : [list, denominator];
 }

--- a/packages/time-signature/test.ts
+++ b/packages/time-signature/test.ts
@@ -17,6 +17,18 @@ describe("time-signature", () => {
     expect(TimeSignature.get("0/0").empty).toBe(true);
   });
 
+  test("does not throw on input that is not a time signature", () => {
+    // Regression for #490: "C" (common time) and other non-matching input
+    // used to throw "Cannot read properties of undefined (reading 'split')".
+    for (const input of ["C", "", "x", "4", "/", "abc"]) {
+      expect(() => TimeSignature.get(input)).not.toThrow();
+      expect(TimeSignature.get(input).empty).toBe(true);
+    }
+    // A valid signature still parses correctly.
+    expect(TimeSignature.get("4/4").empty).toBe(false);
+    expect(TimeSignature.get("4/4").name).toBe("4/4");
+  });
+
   test("simple", () => {
     expect(TimeSignature.get("4/4").type).toEqual("simple");
     expect(TimeSignature.get("3/4").type).toEqual("simple");


### PR DESCRIPTION
Fixes #490

## Problem
`TimeSignature.get` / `parse` throw `TypeError: Cannot read properties of undefined (reading 'split')` on any string that doesn't match the `<n>/<n>` regex -- most notably `"C"` (common time), but also `""`, `"x"`, etc.

## Root cause
In `parse`, `const [_, up, low] = REGEX.exec(literal) || []` yields an `undefined` `up` when the regex doesn't match. That recurses into the array branch where `up.split("+")` (index.ts:72) throws.

## Fix
Add a defensive guard: when `up` is not a string (regex miss), return the zeroed parse `[0, 0]`, which the existing `build()` already maps to the `NONE` / empty signature -- the same path invalid inputs like `"0/0"` already take. No behavior change for valid input.

## Tests
Added a regression test in `packages/time-signature/test.ts` asserting that `"C"`, `""`, `"x"`, `"4"`, `"/"`, `"abc"` do not throw and return the empty signature, and that `"4/4"` still parses correctly.

- Reverting the fix -> the new test reproduces the exact `Cannot read properties of undefined (reading 'split')` error (red).
- With the fix -> package tests 8/8 pass; full suite 283/283 pass; lint and tsdown build clean (green).

---
This contribution was prepared with AI assistance.